### PR TITLE
Update python command to remove mypy caches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ What does it clean?
 
 * Python - removes:
   * `__pycache__` directories and their contents.
+  * `.mypy_cache` directories and their contents.
   * `.pyc` files.
 
 * Editors - removes Emacs/Vim backups and autosaves.

--- a/clean.go
+++ b/clean.go
@@ -89,6 +89,7 @@ func main() {
 			if *c_py || c_a {
 				// Python.
 				if n == "__pycache__" ||
+					n == ".mypy_cache" ||
 					strings.HasSuffix(n, ".pyc") {
 					delete = true
 				}


### PR DESCRIPTION
The mypy cache is automatically generated when using mypy for type hinting. These folders are not necessary past the checking, and so should be cleaned up by this tool.

- Update the logic to remove .mypy_cache files.
- Update the readme to confirm this logic.